### PR TITLE
engine-changes

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/App.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/App.java
@@ -38,7 +38,6 @@ public class App extends Application implements StateChangeListener {
     Text txtGameData;
     GameModel gameModel;
     EngineOutputView engineOutputView;
-    EngineController engineController;
 
     ToggleButton tglEngineOnOff;
 
@@ -369,9 +368,12 @@ public class App extends Application implements StateChangeListener {
 
         // connect mode controller
         engineOutputView = new EngineOutputView(gameModel, txtEngineOut);
+        // This will set the name of the restored active engine in the
+        // engineOutputView. Previously it was always "Stockfish (internal)
+        // at startup.
+        engineOutputView.setEngineId(gameModel.getActiveEngineID());
         modeMenuController = new ModeMenuController(gameModel, engineOutputView);
-        engineController = new EngineController(modeMenuController);
-        modeMenuController.setEngineController(engineController);
+        // Creation of engineController has been moved inside ModeMenuController.
 
         gameModel.addListener(engineOutputView);
 
@@ -468,14 +470,14 @@ public class App extends Application implements StateChangeListener {
         btnAddEngineLine.setOnAction(actionEvent -> {
             int currentMultiPv = gameModel.getMultiPv();
             gameModel.setMultiPv(currentMultiPv+1);
-            engineController.sendCommand("setoption name MultiPV value " + gameModel.getMultiPv());
+            modeMenuController.engineSetOptionMultiPV(gameModel.getMultiPv());
             gameModel.triggerStateChange();
         });
 
         btnRemoveEngineLine.setOnAction(actionEvent -> {
             int currentMultiPv = gameModel.getMultiPv();
             gameModel.setMultiPv(currentMultiPv-1);
-            engineController.sendCommand("setoption name MultiPV value " + gameModel.getMultiPv());
+            modeMenuController.engineSetOptionMultiPV(gameModel.getMultiPv());
             gameModel.triggerStateChange();
         });
 
@@ -927,7 +929,7 @@ public class App extends Application implements StateChangeListener {
         gameModel.saveTheme();
         gameModel.savePaths();
 
-        engineController.sendCommand("quit");
+        modeMenuController.stopEngine();
         ArrayList<Task> runningTasks = gameModel.getPgnDatabase().getRunningTasks();
         for (Task task : runningTasks) {
             task.cancel();

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -110,6 +110,7 @@ public class DialogEngines {
 
         stage = new Stage();
         stage.initModality(Modality.APPLICATION_MODAL);
+        stage.setTitle("Chessengines:");
 
         btnOk = new Button();
         btnOk.setText("OK");
@@ -120,7 +121,8 @@ public class DialogEngines {
 
         HBox hbButtons = new HBox();
         hbButtons.getChildren().addAll(spacer, btnOk, btnCancel);
-        hbButtons.setHgrow(spacer, Priority.ALWAYS);
+	// Got a "warning:static method should be called in a static way" here.
+        HBox.setHgrow(spacer, Priority.ALWAYS);
         hbButtons.setSpacing(10);
 
         VBox vbButtonsRight = new VBox();
@@ -134,17 +136,17 @@ public class DialogEngines {
         vbButtonsRight.getChildren().addAll(btnAdd, btnRemove,
                 spacer1,
                 btnEditParameters, btnResetParameters);
-        vbButtonsRight.setVgrow(spacer1, Priority.ALWAYS);
+        VBox.setVgrow(spacer1, Priority.ALWAYS);
         vbButtonsRight.setSpacing(10);
         vbButtonsRight.setPadding( new Insets(0,0,0,10));
 
         HBox hbMain = new HBox();
         hbMain.getChildren().addAll(engineListView, vbButtonsRight);
-        hbMain.setHgrow(engineListView, Priority.ALWAYS);
+        HBox.setHgrow(engineListView, Priority.ALWAYS);
 
         VBox vbMain = new VBox();
         vbMain.getChildren().addAll(hbMain, hbButtons);
-        vbMain.setVgrow(hbMain, Priority.ALWAYS);
+        VBox.setVgrow(hbMain, Priority.ALWAYS);
         vbMain.setSpacing(10);
         vbMain.setPadding( new Insets(10));
 
@@ -269,8 +271,6 @@ public class DialogEngines {
             try {
                 String line;
 
-                //System.err.println("file != null, starting engine");
-
                 Process engineProcess = Runtime.getRuntime().exec(file.getAbsolutePath());
                 //OutputStream stdout = engineProcess.getOutputStream ();
                 //InputStream stderr = engineProcess.getErrorStream ();
@@ -280,47 +280,47 @@ public class DialogEngines {
                 BufferedWriter bro = new BufferedWriter (new OutputStreamWriter(engineProcess.getOutputStream()));
                 BufferedReader bre = new BufferedReader (new InputStreamReader(engineProcess.getErrorStream()));
 
-                for(int i=0;i<20;i++) {
-                    try {
-                        Thread.sleep(40);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                }
-
+                // Ask the engine if it's a UCI engine and ask for it's
+                // configuration parameters
                 bro.write("uci\n");
                 bro.flush();
 
-                for(int i=0;i<20;i++) {
-                    try {
-                        Thread.sleep(40);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
+                // Waiting for the bri inputbuffer to be filled with engine options
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
 
                 Engine engine = new Engine();
                 engine.setPath(file.getAbsolutePath());
-
                 while(bri.ready()) {
-                    EngineOption engineOption = new EngineOption();
                     line = bri.readLine();
-                    //System.err.println("option: " + line);
+                    if(line.equals("uciok")){
+                        // No more options
+                        break;
+                    }
                     if(line.startsWith("id name")) {
                         engine.setName(line.substring(7).trim());
+                        continue;
                     }
+                    if(line.startsWith("id author")) {
+                        continue;
+                    }
+                    EngineOption engineOption = new EngineOption();
                     boolean parsed = engineOption.parseUciOptionString(line);
                     if(parsed) {
                         engine.options.add(engineOption);
                     }
                 }
-                //bro.write("quit\n");
+                // This line with the quit command was outcommented, but I think
+                // it could be good if the engine process itself has control of
+                // how it exits, it may have some resources allocated that needs
+                // to be closed down in a gentle way, instead of just calling
+                // destroy further below.
+                bro.write("stop\n");
+                bro.write("quit\n");
                 bro.flush();
-
-                bri.close();
-                bro.close();
-                bre.close();
-
                 try {
                     boolean finished = engineProcess.waitFor(500, TimeUnit.MILLISECONDS);
                     if(!finished) {
@@ -329,6 +329,10 @@ public class DialogEngines {
                 } catch(InterruptedException e) {
                     e.printStackTrace();
                 }
+
+                bri.close();
+                bro.close();
+                bre.close();
 
                 if(engine.getName() != null && !engine.getName().isEmpty()) {
                     engineList.add(engine);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogNewGame.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogNewGame.java
@@ -148,10 +148,16 @@ public class DialogNewGame {
                     txtStrength.setText("Elo "+ strength);
                 })
         );
+        
         sliderStrength.setValue(3000);
         sliderStrength.setValue(tmpStrength);
         sliderStrength.setStyle("-show-value-on-interaction: false;");
         sliderStrength.setDisable(true);
+        
+        if (!supportsUciLimitStrength) {
+            txtStrength.setText("N.A.");
+            txtStrength.setDisable(true);
+        }
 
         sliderThinkTime.setMin(1);
         sliderThinkTime.setMax(7);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
@@ -31,7 +31,9 @@ import java.util.regex.Pattern;
 
 public class EngineInfo {
 
-    final Pattern READYOK        = Pattern.compile("readok");
+    
+    // readok? I removed this unused pattern.
+    //final Pattern READYOK        = Pattern.compile("readok");
     final Pattern SCORECP        = Pattern.compile("score\\scp\\s-{0,1}(\\d)+");
     final Pattern NPS            = Pattern.compile("nps\\s(\\d)+");
     final Pattern SELDEPTH       = Pattern.compile("seldepth\\s(\\d)+");

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
@@ -151,6 +151,10 @@ public class EngineOutputView implements StateChangeListener {
         }
     }
 
+    // Added this to be able to set engineId from App and ModeMenuController
+    public void setEngineId(String engineId) {
+        this.engineId.setText(engineId);
+    }
 
     @Override
     public void stateChange() {

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
 
 public class EngineThread extends Thread {
 
@@ -33,9 +34,8 @@ public class EngineThread extends Thread {
     static final Pattern REG_STRENGTH = Pattern.compile("UCI_Elo value \\d+");
 
     private final StringProperty stringProperty;
-    private final int counter = 0;
 
-    private final BlockingQueue cmdQueue;
+    private final BlockingQueue<String> cmdQueue;
     Process engineProcess;
     BufferedReader engineOutput;
     BufferedWriter engineInput;
@@ -46,11 +46,9 @@ public class EngineThread extends Thread {
     private final EngineInfo engineInfo;
 
     private boolean readyok = false;
-    private boolean requestedReadyOk = false;
-    //private boolean engineRunning = false;
-    private boolean inGoInfinite = false;
+    private boolean uciok = false;
 
-    public EngineThread(BlockingQueue cmdQueue) {
+    public EngineThread(BlockingQueue<String> cmdQueue) {
         this.engineInfo = new EngineInfo();
         this.cmdQueue = cmdQueue;
         stringProperty = new SimpleStringProperty(this, "String", "");
@@ -59,6 +57,11 @@ public class EngineThread extends Thread {
         setDaemon(true);
     }
 
+    public synchronized boolean engineIsOn() {
+        return (engineProcess != null && engineProcess.isAlive());
+    }
+        
+    // bestmove result comes from the engine via this method.
     public String getString() {
         return stringProperty.get();
     }
@@ -70,14 +73,36 @@ public class EngineThread extends Thread {
     @Override
     public void run() {
         while (running) {
+            // Set the thread to loop at about 1000 times per second.
+            // It Keeps CPU-load down and is probably more than enough.
+        	try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
             if (this.isInterrupted()) {
                 // here: delete process if it exists
-                if(engineProcess != null && engineProcess.isAlive()) {
-                    engineProcess.destroy();
+                if(engineIsOn()) {
+                    try {
+                        // Try to close down the engine the normal way.
+                        engineInput.write("stop\n");
+                        engineInput.flush();
+                        engineInput.write("quit\n");
+                        engineInput.flush();
+                        boolean finished = engineProcess.waitFor(500, TimeUnit.MILLISECONDS);
+                        if(!finished) {
+                            engineProcess.destroy();
+                        }
+                    } catch(IOException | InterruptedException e) {
+                    e.printStackTrace(System.out);
+                    }
                 }
+                // Stop this thread.
                 running = false;
+                continue;
             }
-            // process engine output
+            // Process engine output
             if (engineOutput != null) {
                 int linesRead = 0;
                 try {
@@ -85,23 +110,30 @@ public class EngineThread extends Thread {
                         String line = engineOutput.readLine();
                         if(line.contains("readyok")) {
                             readyok = true;
-                        } else {
-                            if (!line.isEmpty()) {
-                                //lastString = line;
-                                // todo: instead of directly setting bestmove,
-                                // try updating engine info
-                                if(line.startsWith("bestmove")) {
-                                    engineInfo.bestmove = "BESTMOVE|"
-                                            + line.substring(9)
-                                            +"|"+engineInfo.score.get(0)
-                                            +"|"+String.join(" ", engineInfo.pvList)
-                                            +"|"+engineInfo.seesMate.get(0)
-                                            +"|"+engineInfo.mate.get(0)
-                                            +"|"+engineInfo.zobrist;
-                                } else {
-                                    engineInfo.update(line);
-                                }
+                            continue;
+                        }
+                        if(line.contains("uciok")) {
+                            uciok = true;
+                            continue;
+                        }
+                        if (!line.isEmpty()) {
+                            //System.out.println(line);
+                            //lastString = line;
+                            // todo: instead of directly setting bestmove,
+                            // try updating engine info
+                            if(line.startsWith("bestmove")) {
+                                engineInfo.bestmove = "BESTMOVE|"
+                                        + line.substring(9)
+                                        +"|"+engineInfo.score.get(0)
+                                        +"|"+String.join(" ", engineInfo.pvList)
+                                        +"|"+engineInfo.seesMate.get(0)
+                                        +"|"+engineInfo.mate.get(0)
+                                        +"|"+engineInfo.zobrist;
+                                linesRead++;
+                                continue;
                             }
+                            // Update engine info with other ouput-lines
+                            engineInfo.update(line);
                         }
                         linesRead++;
                     }
@@ -123,10 +155,17 @@ public class EngineThread extends Thread {
                 stringProperty.set(engineInfo.bestmove);
                 lastBestmoveUpdate = currentMs;
             }
-            if(engineProcess == null || !engineProcess.isAlive()) { // engine not running
+            if (!engineIsOn()) { 
+                // engine not running
                 if(!cmdQueue.isEmpty()) {
                     try {
-                        String cmd = (String) cmdQueue.take();
+                        // Here we dispose of (or consume) the next command
+                        // sent to a dead engine, or start a new engine process
+                        // if we find a start command.
+                        // This makes it OK for the engineController to
+                        // always send stop and quit first, when restarting
+                        // an engine, without first checking if the engine is on. 
+                        String cmd = (String)cmdQueue.take();
                         if (cmd.startsWith("start")) {
                             // reset engine info if we start
                             engineInfo.clear();
@@ -135,133 +174,170 @@ public class EngineThread extends Thread {
                                 this.engineProcess = new ProcessBuilder(engineCmd).start();
                                 this.engineInput = new BufferedWriter(new OutputStreamWriter(engineProcess.getOutputStream()));
                                 this.engineOutput = new BufferedReader(new InputStreamReader(engineProcess.getInputStream()));
-                                //engineRunning = true;
+                                // Reset some "state" variables.
+                                readyok = false;
+                                uciok = false;
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                e.printStackTrace(System.out);
                             }
                             this.engineInfo.strength = -1;
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        e.printStackTrace(System.out);
                     }
                 }
-            } else { // process is alive -> engine is running
-                if(!cmdQueue.isEmpty()) {
-                    // if we are in go infty, first send stop
-                    if(inGoInfinite) {
-                        try {
-                            engineInput.write("stop\n");
-                            engineInput.flush();
-                            inGoInfinite = false;
-                            continue;
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                    } else {
-                        // not in go infinite mode, then first
-                        // check if engine is ready to receive commands
-                        // but only do this once (check via requestedReadyOk)
-                        if(!readyok) {
-                            // the command uci must be sent immediately after startup
-                            // some engines will not report readyok on isready directly
-                            // after startup (like e.g. arasan). thus always send
-                            // 'uci' without waiting for isready
-                            String cmd = (String) cmdQueue.peek();
-                            if(cmd != null && cmd.equals("uci")) {
-                                try {
-                                    cmdQueue.take();
-                                    engineInput.write("uci\n");
-                                    engineInput.flush();
-                                    continue;
-                                } catch (InterruptedException | IOException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                            if(!requestedReadyOk) {
-                                try {
-                                    engineInput.write("isready\n");
-                                    engineInput.flush();
-                                    requestedReadyOk = true;
-                                    continue;
-                                } catch (IOException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        } else {
-                            // engine is ready to receive commands
-                            // take command from queue
-                            try {
-                                String cmd = (String) cmdQueue.take();
-                                // if the command is "position fen moves", first count the
-                                // numbers of moves so far to generate move numbers in engine info
-                                // todo: needed???
-                                if(cmd.startsWith("sleep")) {
-                                    Thread.sleep(10000);
-                                }
-
-                                if(cmd.startsWith("position")) {
-                                    Matcher matchMoves = REG_MOVES.matcher(cmd);
-                                    int cnt = 0;
-                                    while(matchMoves.find()) {
-                                        cnt++;
-                                    }
-                                    if(cnt > 0) {
-                                        engineInfo.halfmoves = cnt;
-                                    }
-                                }
-
-                                if(cmd.startsWith("position fen")) {
-                                    String fen = cmd.substring(13);
-                                    engineInfo.setFen(fen);
-                                }
-
-                                if(cmd.startsWith("go infinite")) {
-                                    inGoInfinite = true;
-                                }
-
-                                if(cmd.startsWith("setoption name UCI_Elo")) {
-                                    Matcher matchExpressionStrength = REG_STRENGTH.matcher(cmd);
-                                    if(matchExpressionStrength.find()) {
-                                        engineInfo.strength = Integer.parseInt(matchExpressionStrength.group().substring(14));
-                                    }
-                                }
-
-                                if(cmd.startsWith(("setoption name UCI_LimitStrength value"))) {
-                                    String isActive = cmd.substring(38).strip();
-                                    if(isActive.equals("true")) {
-                                        engineInfo.limitedStrength = true;
-                                    } else {
-                                        engineInfo.limitedStrength = false;
-                                    }
-                                }
-
-                                if(cmd.startsWith("setoption name MultiPV value")) {
-                                    engineInfo.nrPvLines = Integer.parseInt(cmd.substring(29));
-                                }
-
-                                // reset engine info if we quit
-                                if(cmd.contains("quit")) {
-                                    engineInfo.clear();
-                                }
-
-                                // send and flush
-                                try {
-                                    this.engineInput.write(cmd + "\n");
-                                    this.engineInput.flush();
-                                    // if we quit the engine, give some
-                                    // time for the engine to quit
-                                    if(cmd.contains("quit")) {
-                                        Thread.sleep(500);
-                                    }
-                                    continue;
-                                } catch (IOException e) {
-                                    e.printStackTrace();
-                                }
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
-                        }
+                continue;
+            }
+            // When we have come this far in the while-loop
+            // we know that the process is alive -> engine is running.
+            // The commands uci, quit, setoption and isready are
+            // treated in special ways. We are not expecting any
+            // other commands from the engine controller until isready
+            // has been sent at least once and we have received readyok
+            // from the engine.
+            if(!cmdQueue.isEmpty()) {
+                // Don't remove from queue until we know which command it is.
+                // It could be some other command just waiting for us to
+                // pass the readyok check below, now or in the next loop, maybe.
+                String cmd = (String) cmdQueue.peek();
+                if(cmd == null) {
+                    // What to do here? 
+                    // Better luck next loop!
+                    continue;
+                }
+                
+                // I noticed that even after stop, quit and waiting for
+                // the process to die, the process.isAlive() method took time
+                // before it answered false. So when restarting, the start
+                // command was being sent to the dead engine as a normal
+                // command below. The following statement prevents that. 
+                if(cmd.startsWith("start")) {
+                    continue;
+                }
+                
+                // The command uci must be sent immediately after startup.
+                // Some engines will not report readyok on isready directly
+                // after startup (like e.g. arasan). thus we require of the
+                // engine controller to always send 'uci' after starting an
+                // engine process by the start command.
+                if(cmd.equals("uci")) {
+                    try {
+                        cmdQueue.take();
+                        engineInput.write(cmd + "\n");
+                        engineInput.flush();
+                        // Set the uciok flag to false.
+                        // This thread won't send any other commands
+                        // until uciok has been received.
+                        uciok = false;
+                    } catch (InterruptedException | IOException e) {
+                        e.printStackTrace(System.out);
                     }
+                    continue;
+                }
+                
+                if(!uciok) {
+                    // Go no further until we have received uciok.
+                    continue;
+                }
+                
+                // When we have reached this point in the while-loop
+                // we know that the engine is ready to receive other 
+                // commands than uci. We could always be ready to send
+                // the quit command if it appears here, (even before isready).
+                if(cmd.equals("quit")) {
+                    try {
+                        // reset engine info if we quit
+                        engineInfo.clear();
+                        cmdQueue.take();
+                        engineInput.write(cmd + "\n");
+                        engineInput.flush();
+                        // and wait for engine process to die.
+                        boolean finished = engineProcess.waitFor(500, TimeUnit.MILLISECONDS);
+                        if(!finished) {
+                            engineProcess.destroy();
+                            // System.out.println("Engine has been destroyed."); 
+                        }
+                        // else
+                        //    System.out.println("Engine has died a natural death.");
+                    } catch (InterruptedException | IOException e) {
+                        e.printStackTrace(System.out);
+                    }
+                    continue;
+                }
+
+                // We can (and maybe should, according to the UCI-protocol),
+                // be ready to send the setoption commands directly after uciok
+                // has been received.
+                if(cmd.startsWith("setoption")) {
+                    try {
+                        // Some special actions to do before sending:
+                        if(cmd.startsWith("setoption name Skill Level")) {
+                            Matcher matchExpressionStrength = REG_STRENGTH.matcher(cmd);
+                            if(matchExpressionStrength.find()) {
+                                engineInfo.strength = Integer.parseInt(matchExpressionStrength.group().substring(18));
+                            }
+                        }
+                        if(cmd.startsWith("setoption name MultiPV value")) {
+                            engineInfo.nrPvLines = Integer.parseInt(cmd.substring(29,30));
+                        }
+                        cmdQueue.take();
+                        engineInput.write(cmd + "\n");
+                        engineInput.flush();
+                    } catch (IOException | InterruptedException e) {
+                        e.printStackTrace(System.out);
+                    }
+                    continue;                        
+                }
+                
+                if(cmd.equals("isready")) {
+                    try {
+                        // We wish to be able to send isready more than
+                        // once during the lifetime of an engineprocess,
+                        // so the next line is important.
+                        readyok = false;
+                        cmdQueue.take();
+                        engineInput.write(cmd + "\n");
+                        engineInput.flush();
+                    } catch (IOException | InterruptedException e) {
+                        e.printStackTrace(System.out);
+                    }
+                    continue;
+                }
+                
+                if(!readyok) {
+                    // Wait for readyok before proceeding to
+                    // the sending of other commands below.
+                    continue;
+                }
+
+                try {
+                    cmd = (String) cmdQueue.take();
+                    // if the command is "position fen moves", first count the
+                    // numbers of moves so far to generate move numbers in engine info
+                    // todo: needed?
+                    if(cmd.startsWith("position fen")) {
+                        Matcher matchMoves = REG_MOVES.matcher(cmd);
+                        int cnt = 0;
+                        while(matchMoves.find()) {
+                            cnt++;
+                        }
+                        if(cnt > 0) {
+                            engineInfo.halfmoves = cnt;
+                        }
+                        String fen = cmd.substring(13);
+                        engineInfo.setFen(fen);
+                    }
+                   
+                    // All other commands can be sent as they are,
+                    // without any action.
+                    try {
+                        this.engineInput.write(cmd + "\n");
+                        this.engineInput.flush();
+                    } catch (IOException e) {
+                        e.printStackTrace(System.out);
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace(System.out);
                 }
             }
         }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/GameModel.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/GameModel.java
@@ -130,7 +130,9 @@ public class GameModel {
         internalElo.name = "UCI_Elo";
         internalElo.spinMin = 1320;
         internalElo.spinMax = 3190;
-        internalElo.spinDefault = 3190;
+	// Previously 3190 wich surprisingly caused me to
+	// beat stockfish without any problems.
+        internalElo.spinDefault = 1320;
         internalElo.spinValue = 3190;
         internalElo.type = EngineOption.EN_OPT_TYPE_SPIN;
 
@@ -592,6 +594,13 @@ public class GameModel {
             }
         }
     }
+
+    // This "wrapper-method" became necessary to be able to
+    // set engineID in engineOutputView from App
+    public String getActiveEngineID() {
+        return activeEngine.getName();
+    }
+    
 }
 
 


### PR DESCRIPTION
Hello agan Dominik, Torsten here!
I've had an engine_improvements-branch in my forked repo of jfxchess (jerry)
for a long time and mostly used that branch when running jfxchess.
Recently I found some new problems which made me make some new changes on the branch, and it gave me a reason to send all the changes as a pull-request. 
You can take it as is, change it any way you like or take parts of it to fix some problems, no hurry.

There are quite a lot of changes, and to make your review easier I'll walk you through the changes file by file:

#### GameModel

Here I just changed a default value and added a get-method. 
The default value was actually a bug fix!
I noticed recently that Stockfish internal played like a..., well a 1320-player.
Other engines played OK as usual. It took me a while before I understood
why:
Stockfish internal is the engine which gets some of its options set in the program,
other engines are asked for their options and default values in DialogEngines.java. It
turned out that Stockfish 17 has a default value of 1320 for UCI_Elo, but it was set to 3190 in the program. The thing is that before sending an option value there is a check in the code that it's not the same as the default value. Trying to set the value to 3190, with a default value of 3190 meant that the value never was sent to the engine. As UCI_LimitStrength was set to true, stockfish still used its own default value 1320 for the elo.

(It got even more weird when I thought I had fixed the problem by setting the correct value and stockfish still played like 1320. But I was playing stockfish 14 then (as internal , maybe by a fix) and that version has a max Elo of 2800-something. When trying to set 3190 apparently stockfish 14 just refused , and kept using it's low Elo default value.)
Maybe an idea would be to also ask stockfish internal for it's values as well as other engines, and then you wouldn't have to change values for a new stockfish release ever again.

However, after just changing the default value to 1320 in the code, with stockfish 17 as internal engine it now works well again and, as I wrote, for other engines than the internal this was never a problem. And even if they happen to have 3190 as default they would just fallback to exactly 3190 anyway ;-)

#### DialogNewGame

When starting a game against an engine which doesn't support UCI_LimitStrength,
previously "elo 1200" was shining in bright white in the label next to the slidingbar.
(I'm running in dark mode) I changed it to "N.A." (for not applicable) and disabled the label. Looks OK.

#### EngineInfo

First changed, but then simply removed, unused pattern READYOK which was set to "readok" without y. This change was just an editing change that happened to be included. Maybe there are more unused patterns?.

#### DialogEngines

Added a title to the dialog
Removed some warnings I got with another version of javafx
skipped "id author"-option

included wait for uciok
sent stop and quit to the engine before destroying engineProcess.

#### EngineOutputView

Added a setEngineID-method.
This has to do with another issue:
When I choose another engine than internal in DialogEngines and press OK, the
engineID in the EngineOutputView doesn't change. It's not until something is chosen, e.g. "play as white" , that the new Engine name pops up.
I think it would be good if the Engine name was visible before we try to do something with that engine. Another time when this set-method is used is right at the startup of the program. It always says Stockfish (internal) even if another restored engine is active. So, that's the reason for this new setEngineID method and the new getActiveEngineID method I mentioned in GameModel.

#### EngineController

The general idea was to move knowledge of Engine-specific things into the EngineController., such as UCI-commands and checks like isInternal and supportsLimitStrength before sending the commands.

Most of these changes were made a long time ago. I don't remember exactly, but
I had some problems with some engines (not stockfish I think) not quitting correctly and after changing modes back and forth there could even be two EngineProcesses at the same time when I checked with the ps command. Don't know if this solved any problem or if it was solved somewhere inside the enginThread, but It seems that I wanted to be absolutely sure that there was only one engineThread instance, so I create that instance once in the EngineController constructor, and it will last for as long the program is running. It will not load the processor too hard when the engineProcess is not running, because of a sleep inside the loop in the Enginethread.

I put the content of startEngineThread() inside the constructor().

Added new stopEngine() and restartEngine() functions to be called from
ModeMenuController to always start and stop the engine in the same way.
Added an isready after newgame (and then I had to make the engineThread able to wait for readyok more than once).

(All the commands go through sendCommand() just because I wanted one place where I could put a System.out.println() to see them, and I didn't have to write try-catch each time ;-) ) (Not exactly true really, because the EngineThread sometimes, and the dialogEngines send commands directly into their cmdQueue.)

#### ModeMenuController

I moved the EngineController instance from App.java to here. There's no reason for this really. (Well, I had a reason: I was experimenting with a "mini-jerry"-program and didn't want to bring in the whole App.java)

I do something with previousMultiPV. This could be a problem-fix, I don't remember. Maybe you can figure that out.

Most of the changes consist only of calling the methods in engineContoller instead of specifing the commands Explicitly here.

Well, there's one difference. I set uciLimitStrength directly to the engine when it has been started. You manipulate the option parameter first so It will be sent when the engine starts. I think it's best to keep the engine option as it was set in the dialog-engines, so it doesn't play with another Uci_LimitStrength the next time it's started.
(I mean other engines that support UCI_LimitStrength, not the internal Stockfish.)
Does this make sense?. Maybe it doesn't matter anyway.

Another problem: Just a while ago I realized that it's dangerous to set UCI_limitStrength to true as in activatePlayWhiteMode() and activatePlayBlackMode(). It's probably OK for the internal engine, but what if it's an engine we have added that supports UCI_LimitStrength, Arasan or just a newer version of Stockfish maybe? It's very probable that we have never set an ELO-value for the engine. If then the first thing we do with this engine is e.g. "play as white". We will set UCI_LimitStrength to true, and the engine will use it's low default-ELO when playing. Yep, that's what happened when I tried. That problem disappeared, of course, when I added
if (gameModel.activeEngine.isInternal()). Don't know if it's a full solution though.

If we are playing an engine and then choose Engines... in the Mode-menu, then the
engineOutputwindow will show "Off", but the engineProcess is still running.
I think there were (and perhaps are more such cases, as after checkmate for instance). Maybe that was deliberate, but I call activateEnterMovesMode which also stops the engine.

There's one change related to "new engine name not showing up in outputView when chosen in dialogEngines"

And then this previousMultiPv thing I can't remember. (maybe something with restored activeEngine)

#### App

Well, there was this moving of engineController which is visible in some of the changes.

The "restored active engine not showing in outputview at start".

Some UCI commands not directly visible anymore.

#### EngineThread

I tried to make it more robust and also more "UCI-Protocol friendly", mostly waiting for uciok and readyok not only once (isready should be sent after newgame e.g.). I found it easier to think in a while-continue structure, so some else-cases disappeared. Changing the structure caused many diffs. With this file it's probably best to read it through, and not just look at diffs. It's well commented. I think it solved some problems with stopping and restaring some engines, but im not 100% sure. I have used this version of enginthread quite a lot.

I promise to send you smaller pull-requests in the future!