### PR TITLE
Engine changes

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngineOptions.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngineOptions.java
@@ -88,9 +88,9 @@ public class DialogEngineOptions {
             // ignore multipv and do not display this to the user
             // as this is completely handled directly in the GUI
             // by the comboBox above the engine window
-            if(enOpt.name.toLowerCase().contains("multipv")) {
-                continue;
-            }
+            //if(enOpt.name.toLowerCase().contains("multipv")) {
+            //    continue;
+            //}
 
             Label lblEnOpt = new Label(enOpt.name+":");
             gridPane.add(lblEnOpt, 0, i);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogNewGame.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogNewGame.java
@@ -148,10 +148,16 @@ public class DialogNewGame {
                     txtStrength.setText("Elo "+ strength);
                 })
         );
+        
         sliderStrength.setValue(3000);
         sliderStrength.setValue(tmpStrength);
         sliderStrength.setStyle("-show-value-on-interaction: false;");
         sliderStrength.setDisable(true);
+        
+        if (!supportsUciLimitStrength) {
+            txtStrength.setText("N.A.");
+            txtStrength.setDisable(true);
+        }
 
         sliderThinkTime.setMin(1);
         sliderThinkTime.setMax(7);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
@@ -18,6 +18,7 @@
 
 package org.asdfjkl.jfxchess.gui;
 
+import static java.lang.Integer.min;
 import java.util.ArrayList;
 
 public class Engine {
@@ -37,6 +38,16 @@ public class Engine {
 
     public boolean isInternal() { return isInternal; }
     public void setInternal(boolean internal) { this.isInternal = internal; }
+    
+    public void addEngineOption(EngineOption option) {
+        // Special case for MultiPV.
+        // Manipulates spinMax value if it's higher than MAX_PV.
+        
+        if (option.name.equals("MultiPV")) {
+           option.spinMax = min(option.spinMax,GameModel.MAX_PV); 
+        }
+        options.add(option);
+    }
 
     public String writeToString() {
         StringBuilder sb = new StringBuilder();
@@ -100,7 +111,7 @@ public class Engine {
                 if(option.type == EngineOption.EN_OPT_TYPE_COMBO) {
                     option.comboValue = values[i+1];
                 }
-                options.add(option);
+                addEngineOption(option);
             }
         }
     }
@@ -113,7 +124,7 @@ public class Engine {
         copy.isInternal = this.isInternal;
 
         for(EngineOption option : options) {
-            copy.options.add(option);
+            copy.addEngineOption(option);
         }
 
         return copy;
@@ -140,9 +151,25 @@ public class Engine {
         }
         return 1;
     }
+    
+    public int getMultiPV() {
+        for (EngineOption option : options) {
+            if (option.name.equals("MultiPV")) {
+                return option.spinValue;
+            }
+        }
+        return 1;
+    }
+
+    public void setMultiPV(int multiPv) {
+        for (EngineOption option : options) {
+            if (option.name.equals("MultiPV")) {
+                option.spinValue = multiPv;
+            }
+        }
+    }
 
     public int getUciElo() {
-
         for (EngineOption option : options) {
             if (option.name.equals("UCI_Elo")) {
                 return option.spinValue;
@@ -195,11 +222,21 @@ public class Engine {
 
     }
 
-    public void setUciLimitStrength(boolean val) {
+    // public void setUciLimitStrength(boolean val) {
+    //     for (EngineOption option : options) {
+    //         if (option.name.equals("UCI_LimitStrength")) {
+    //             option.checkStatusValue = val;
+    //         }
+    //     }
+    // }
+    
+    public boolean getUciLimitStrength() {
         for (EngineOption option : options) {
             if (option.name.equals("UCI_LimitStrength")) {
-                option.checkStatusValue = val;
+               return option.checkStatusValue;
             }
         }
+        return false;
     }
+            
 }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
@@ -31,7 +31,9 @@ import java.util.regex.Pattern;
 
 public class EngineInfo {
 
-    final Pattern READYOK        = Pattern.compile("readok");
+    
+    // readok? I removed this unused pattern.
+    //final Pattern READYOK        = Pattern.compile("readok");
     final Pattern SCORECP        = Pattern.compile("score\\scp\\s-{0,1}(\\d)+");
     final Pattern NPS            = Pattern.compile("nps\\s(\\d)+");
     final Pattern SELDEPTH       = Pattern.compile("seldepth\\s(\\d)+");
@@ -98,6 +100,7 @@ public class EngineInfo {
     public void clear() {
         id = "";
         strength = -1;
+        limitedStrength = false;
         fullMoveNumber = 1;
         halfmoves = 0;
         currentMove = "";
@@ -115,7 +118,7 @@ public class EngineInfo {
         turn = CONSTANTS.WHITE;
 
         fen = "";
-        nrPvLines = 1;
+        //nrPvLines = 1;
 
         bestmove = "";
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
@@ -44,6 +44,8 @@ public class EngineOutputView implements StateChangeListener {
     private final ArrayList<Text> pvLines;
 
     private boolean isEnabled = true;
+    
+    private boolean pvLinesAreEnabled = true;
 
     private TextFlow txtEngineOut;
 
@@ -57,12 +59,6 @@ public class EngineOutputView implements StateChangeListener {
         Text pvLine = new Text("");
         this.pvLines = new ArrayList<Text>();
         this.pvLines.add(pvLine);
-        /*
-        this.pv1 = new Text("");
-        this.pv2 = new Text("");
-        this.pv3 = new Text("");
-        this.pv4 = new Text("");
-        */
 
         Text spacer1 = new Text("     ");
         Text spacer2 = new Text("     ");
@@ -79,17 +75,6 @@ public class EngineOutputView implements StateChangeListener {
                 new Text(System.lineSeparator()),
                 pvLines.get(0),
                 new Text(System.lineSeparator()));
-
-        /*
-                this.pv1,
-                new Text(System.lineSeparator()),
-                this.pv2,
-                new Text(System.lineSeparator()),
-                this.pv3,
-                new Text(System.lineSeparator()),
-                this.pv4);
-        */
-        //this.txtEngineOut.getChildren().addAll(currentEval);
     }
 
     public void enableOutput() { isEnabled = true; }
@@ -109,12 +94,6 @@ public class EngineOutputView implements StateChangeListener {
         for(Text pvLine : pvLines) {
             pvLine.setText("");
         }
-        /*
-        pv1.setText("");
-        pv2.setText("");
-        pv3.setText("");
-        pv4.setText("");
-        */
     }
 
     public void setText(String info) {
@@ -134,7 +113,10 @@ public class EngineOutputView implements StateChangeListener {
             if (infos.length > 4 && !infos[4].isEmpty()) {
                 depth.setText(infos[4]);
             }
-
+            if(!pvLinesAreEnabled) {
+                return;
+            }
+            
             if(infos.length > 5 && !infos[5].isEmpty()) {
                 pvLines.get(0).setText(infos[5]);
             }
@@ -151,23 +133,47 @@ public class EngineOutputView implements StateChangeListener {
         }
     }
 
-
-    @Override
-    public void stateChange() {
-
-        if(gameModel.wasMultiPvChanged()) {
-            // remove all old widgets
-            int cntChildren = txtEngineOut.getChildren().size();
-            txtEngineOut.getChildren().remove(7, cntChildren);
-            pvLines.clear();
+    public void disablePVLines() {
+        if (pvLinesAreEnabled) {
+            resetPVLines();
+            depth.setText("");
+	    nps.setText("");
         }
-        gameModel.setMultiPvChange(false);
-        for(int i=0;i<gameModel.getMultiPv();i++) {
+        pvLinesAreEnabled = false;
+    }
+    
+    public void enablePVLines() {
+        pvLinesAreEnabled = true;
+    }
+
+    private void resetPVLines() {
+        int cntChildren = txtEngineOut.getChildren().size();
+        txtEngineOut.getChildren().remove(7, cntChildren);
+        pvLines.clear();
+        for (int i = 0; i < gameModel.getMultiPv(); i++) {
             Text pvLine = new Text("");
             pvLines.add(pvLine);
             txtEngineOut.getChildren().add(pvLine);
             txtEngineOut.getChildren().add(new Text(System.lineSeparator()));
         }
+    }
+
+    @Override
+    public void stateChange() {
+        if(gameModel.wasMultiPvChanged()) {
+            gameModel.setMultiPvChange(false);
+        }
+        // I think that if we always reset the pvlines here then there's 
+        // no need for the wasMultiPvCganged functionality in Gamemodel.
+	// This is the only place where it's used, so it could just as well
+	// be removed.
+        resetPVLines();
+        // The last depth-text from analysis mode remained after mode change 
+        // to playing black or white (or to a new game).
+        depth.setText("");
+        // There was a similar problem with nps (but this didn't seem to
+	// help completely).
+	nps.setText("");
     }
 
 }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
 
 public class EngineThread extends Thread {
 
@@ -33,9 +34,8 @@ public class EngineThread extends Thread {
     static final Pattern REG_STRENGTH = Pattern.compile("UCI_Elo value \\d+");
 
     private final StringProperty stringProperty;
-    private final int counter = 0;
 
-    private final BlockingQueue cmdQueue;
+    private final BlockingQueue<String> cmdQueue;
     Process engineProcess;
     BufferedReader engineOutput;
     BufferedWriter engineInput;
@@ -46,11 +46,9 @@ public class EngineThread extends Thread {
     private final EngineInfo engineInfo;
 
     private boolean readyok = false;
-    private boolean requestedReadyOk = false;
-    //private boolean engineRunning = false;
-    private boolean inGoInfinite = false;
+    private boolean uciok = false;
 
-    public EngineThread(BlockingQueue cmdQueue) {
+    public EngineThread(BlockingQueue<String> cmdQueue) {
         this.engineInfo = new EngineInfo();
         this.cmdQueue = cmdQueue;
         stringProperty = new SimpleStringProperty(this, "String", "");
@@ -59,6 +57,11 @@ public class EngineThread extends Thread {
         setDaemon(true);
     }
 
+    public synchronized boolean engineIsOn() {
+        return (engineProcess != null && engineProcess.isAlive());
+    }
+        
+    // bestmove result comes from the engine via this method.
     public String getString() {
         return stringProperty.get();
     }
@@ -67,41 +70,109 @@ public class EngineThread extends Thread {
         return stringProperty;
     }
 
+    // EngineThread is the only object with access to the EngineInfo.
+    // EngineInfo is assembled into a textstring which is is sent to
+    // the EngineOutputview at regular intervals.
+    // I added four methods below to be able to send info to the
+    // outputView without sending the UCI-commands to the engine.
+    public void engineInfoSetID(String engineID)
+    {
+        // System.out.println("engineInfoSetID " + engineID);
+        engineInfo.id = engineID;
+    }
+
+    public void engineInfoSetLimitedStrength(boolean b)
+    {
+        // System.out.println("engineInfoSetLimitedStrength " + b);
+        engineInfo.limitedStrength = b;
+    }
+
+    public void engineInfoSetStrength(int elo)
+    {
+        // System.out.println("engineInfoSetStrength " + elo);
+        engineInfo.strength = elo;
+    }
+
+    public void engineInfoSetPVLines(int n)
+    {
+        // System.out.println("engineInfoSetPvLines " + n);
+        engineInfo.nrPvLines = n;
+    }
+
+    private void take_write_and_flush(String cmd) {
+	try {
+	    cmdQueue.take();
+	    engineInput.write(cmd + "\n");
+	    engineInput.flush();
+	} catch (IOException | InterruptedException e) {
+	    e.printStackTrace(System.out);
+	}
+    }
+
     @Override
     public void run() {
+        int savedElo = -1;
         while (running) {
+            // Set the thread to loop at about 1000 times per second.
+            // It Keeps CPU-load down and is probably more than enough.
+        	try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
             if (this.isInterrupted()) {
                 // here: delete process if it exists
-                if(engineProcess != null && engineProcess.isAlive()) {
-                    engineProcess.destroy();
+                if (engineIsOn()) {
+                    try {
+                        // Try to close down the engine the normal way.
+                        engineInput.write("stop\n");
+                        engineInput.flush();
+                        engineInput.write("quit\n");
+                        engineInput.flush();
+                        boolean finished = engineProcess.waitFor(500, TimeUnit.MILLISECONDS);
+                        if (!finished) {
+                            engineProcess.destroy();
+                        }
+                    } catch(IOException | InterruptedException e) {
+                    e.printStackTrace(System.out);
+                    }
                 }
+                // Stop this thread.
                 running = false;
+                continue;
             }
-            // process engine output
+            // Process engine output
             if (engineOutput != null) {
                 int linesRead = 0;
                 try {
                     while (engineOutput.ready() && linesRead < 100) {
                         String line = engineOutput.readLine();
-                        if(line.contains("readyok")) {
+                        if (line.contains("readyok")) {
                             readyok = true;
-                        } else {
-                            if (!line.isEmpty()) {
-                                //lastString = line;
-                                // todo: instead of directly setting bestmove,
-                                // try updating engine info
-                                if(line.startsWith("bestmove")) {
-                                    engineInfo.bestmove = "BESTMOVE|"
-                                            + line.substring(9)
-                                            +"|"+engineInfo.score.get(0)
-                                            +"|"+String.join(" ", engineInfo.pvList)
-                                            +"|"+engineInfo.seesMate.get(0)
-                                            +"|"+engineInfo.mate.get(0)
-                                            +"|"+engineInfo.zobrist;
-                                } else {
-                                    engineInfo.update(line);
-                                }
+                            continue;
+                        }
+                        if (line.contains("uciok")) {
+                            uciok = true;
+                            continue;
+                        }
+                        if (!line.isEmpty()) {
+                            //lastString = line;
+                            // todo: instead of directly setting bestmove,
+                            // try updating engine info
+                            if (line.startsWith("bestmove")) {
+                                engineInfo.bestmove = "BESTMOVE|"
+                                        + line.substring(9)
+                                        +"|"+engineInfo.score.get(0)
+                                        +"|"+String.join(" ", engineInfo.pvList)
+                                        +"|"+engineInfo.seesMate.get(0)
+                                        +"|"+engineInfo.mate.get(0)
+                                        +"|"+engineInfo.zobrist;
+                                linesRead++;
+                                continue;
                             }
+                            // Update engine info with other ouput-lines
+                            engineInfo.update(line);
                         }
                         linesRead++;
                     }
@@ -110,7 +181,7 @@ public class EngineThread extends Thread {
             }
             // send update
             long currentMs = System.currentTimeMillis();
-            if((currentMs - lastInfoUpdate) > 100) {
+            if ((currentMs - lastInfoUpdate) > 100) {
                 stringProperty.set("INFO " + engineInfo.toString());
                 lastInfoUpdate = currentMs;
             }
@@ -119,14 +190,21 @@ public class EngineThread extends Thread {
             // the window or other inputs, the GUI might skip to handle (the only one)
             // bestmove info. Instead, the GUI will receive bestmove frequently
             // but ignore the info, if already processed.
-            if((currentMs - lastBestmoveUpdate) > 800) {
+            if ((currentMs - lastBestmoveUpdate) > 800) {
                 stringProperty.set(engineInfo.bestmove);
                 lastBestmoveUpdate = currentMs;
             }
-            if(engineProcess == null || !engineProcess.isAlive()) { // engine not running
-                if(!cmdQueue.isEmpty()) {
+            if (!engineIsOn()) {
+                // engine not running
+                if (!cmdQueue.isEmpty()) {
                     try {
-                        String cmd = (String) cmdQueue.take();
+                        // Here we dispose of (or consume) the next command
+                        // sent to a dead engine, or start a new engine process
+                        // if we find a start command.
+                        // This makes it OK for the engineController to
+                        // always send stop and quit first, when restarting
+                        // an engine, without first checking if the engine is on. 
+                        String cmd = (String)cmdQueue.take();
                         if (cmd.startsWith("start")) {
                             // reset engine info if we start
                             engineInfo.clear();
@@ -135,134 +213,173 @@ public class EngineThread extends Thread {
                                 this.engineProcess = new ProcessBuilder(engineCmd).start();
                                 this.engineInput = new BufferedWriter(new OutputStreamWriter(engineProcess.getOutputStream()));
                                 this.engineOutput = new BufferedReader(new InputStreamReader(engineProcess.getInputStream()));
-                                //engineRunning = true;
+                                // Reset some "state" variables.
+                                readyok = false;
+                                uciok = false;
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                e.printStackTrace(System.out);
                             }
                             this.engineInfo.strength = -1;
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        e.printStackTrace(System.out);
                     }
                 }
-            } else { // process is alive -> engine is running
-                if(!cmdQueue.isEmpty()) {
-                    // if we are in go infty, first send stop
-                    if(inGoInfinite) {
-                        try {
-                            engineInput.write("stop\n");
-                            engineInput.flush();
-                            inGoInfinite = false;
-                            continue;
-                        } catch (IOException e) {
-                            e.printStackTrace();
+                continue;
+            }
+            // When we have come this far in the while-loop
+            // we know that the process is alive -> engine is running.
+            // The commands uci, quit, setoption and isready are
+            // treated in special ways. We are not expecting any
+            // other commands from the engine controller until isready
+            // has been sent at least once and we have received readyok
+            // from the engine.
+            if (!cmdQueue.isEmpty()) {
+                // The problem of sending stop first if we are in "go infinite"-mode
+		// is handled in EngineController.
+		
+                // Don't remove from queue until we know which command it is.
+                // It could be some other command just waiting for us to
+                // pass the readyok check below, now or in the next loop, maybe.
+                String cmd = (String) cmdQueue.peek();
+                if (cmd == null) {
+                    // What to do here? 
+                    // Better luck next loop!
+                    continue;
+                }
+                
+                // I noticed that even after stop, quit and waiting for
+                // the process to die, the process.isAlive() method took time
+                // before it answered false. So when restarting, the start
+                // command was being sent to the dead engine as a normal
+                // command below. The following statement prevents that. 
+                if (cmd.startsWith("start")) {
+                    continue;
+                }
+                
+                // The command uci must be sent immediately after startup.
+                // Some engines will not report readyok on isready directly
+                // after startup (like e.g. arasan). thus we require of the
+                // engine controller to always send 'uci' after starting an
+                // engine process by the start command.
+                if (cmd.equals("uci")) {
+                    take_write_and_flush(cmd);
+		    // Set the uciok flag to false.
+		    // This thread won't send any other commands
+		    // until uciok has been received.
+		    uciok = false;
+                    continue;
+                }
+                
+                if (!uciok) {
+                    // Go no further until we have received uciok.
+                    continue;
+                }
+                
+                // When we have reached this point in the while-loop
+                // we know that the engine is ready to receive other 
+                // commands than uci. We could always be ready to send
+                // the quit command if it appears here, (even before isready).
+                if (cmd.equals("quit")) {
+                    // reset engine info if we quit
+                    engineInfo.clear();
+                    // In case elo has been sent but not limit-strength
+                    // we must clear savedElo here as well
+                    savedElo = -1;
+                    take_write_and_flush(cmd);
+                    try {
+                        // and wait for engine process to die.
+                        boolean finished = engineProcess.waitFor(500, TimeUnit.MILLISECONDS);
+                        if (!finished) {
+                            engineProcess.destroy();
                         }
-                    } else {
-                        // not in go infinite mode, then first
-                        // check if engine is ready to receive commands
-                        // but only do this once (check via requestedReadyOk)
-                        if(!readyok) {
-                            // the command uci must be sent immediately after startup
-                            // some engines will not report readyok on isready directly
-                            // after startup (like e.g. arasan). thus always send
-                            // 'uci' without waiting for isready
-                            String cmd = (String) cmdQueue.peek();
-                            if(cmd != null && cmd.equals("uci")) {
-                                try {
-                                    cmdQueue.take();
-                                    engineInput.write("uci\n");
-                                    engineInput.flush();
-                                    continue;
-                                } catch (InterruptedException | IOException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                            if(!requestedReadyOk) {
-                                try {
-                                    engineInput.write("isready\n");
-                                    engineInput.flush();
-                                    requestedReadyOk = true;
-                                    continue;
-                                } catch (IOException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        } else {
-                            // engine is ready to receive commands
-                            // take command from queue
-                            try {
-                                String cmd = (String) cmdQueue.take();
-                                // if the command is "position fen moves", first count the
-                                // numbers of moves so far to generate move numbers in engine info
-                                // todo: needed???
-                                if(cmd.startsWith("sleep")) {
-                                    Thread.sleep(10000);
-                                }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace(System.out);
+                    }
+                    continue;
+                }
 
-                                if(cmd.startsWith("position")) {
-                                    Matcher matchMoves = REG_MOVES.matcher(cmd);
-                                    int cnt = 0;
-                                    while(matchMoves.find()) {
-                                        cnt++;
-                                    }
-                                    if(cnt > 0) {
-                                        engineInfo.halfmoves = cnt;
-                                    }
-                                }
-
-                                if(cmd.startsWith("position fen")) {
-                                    String fen = cmd.substring(13);
-                                    engineInfo.setFen(fen);
-                                }
-
-                                if(cmd.startsWith("go infinite")) {
-                                    inGoInfinite = true;
-                                }
-
-                                if(cmd.startsWith("setoption name UCI_Elo")) {
-                                    Matcher matchExpressionStrength = REG_STRENGTH.matcher(cmd);
-                                    if(matchExpressionStrength.find()) {
-                                        engineInfo.strength = Integer.parseInt(matchExpressionStrength.group().substring(14));
-                                    }
-                                }
-
-                                if(cmd.startsWith(("setoption name UCI_LimitStrength value"))) {
-                                    String isActive = cmd.substring(38).strip();
-                                    if(isActive.equals("true")) {
-                                        engineInfo.limitedStrength = true;
-                                    } else {
-                                        engineInfo.limitedStrength = false;
-                                    }
-                                }
-
-                                if(cmd.startsWith("setoption name MultiPV value")) {
-                                    engineInfo.nrPvLines = Integer.parseInt(cmd.substring(29));
-                                }
-
-                                // reset engine info if we quit
-                                if(cmd.contains("quit")) {
-                                    engineInfo.clear();
-                                }
-
-                                // send and flush
-                                try {
-                                    this.engineInput.write(cmd + "\n");
-                                    this.engineInput.flush();
-                                    // if we quit the engine, give some
-                                    // time for the engine to quit
-                                    if(cmd.contains("quit")) {
-                                        Thread.sleep(500);
-                                    }
-                                    continue;
-                                } catch (IOException e) {
-                                    e.printStackTrace();
-                                }
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
+                // We can (and maybe should, according to the UCI-protocol),
+                // be ready to send the setoption commands directly after uciok
+                // has been received.
+                if (cmd.startsWith("setoption")) {
+		    if (cmd.startsWith("setoption name UCI_Elo")) {
+                        // We must save the elo value if elo is set before limit-strength
+                        // The value is only valid in connection with limitedStrength == true
+			Matcher matchExpressionStrength = REG_STRENGTH.matcher(cmd);
+			if (matchExpressionStrength.find()) {
+			    savedElo = Integer.parseInt(matchExpressionStrength.group().substring(14));
+			}
+                        if (engineInfo.limitedStrength == true) {
+                            engineInfo.strength = savedElo;
+                            savedElo = -1;
                         }
+		    }
+                    if (cmd.startsWith(("setoption name UCI_LimitStrength value"))) {
+			String isActive = cmd.substring(38).strip();
+			if (isActive.equals("true")) {
+			    engineInfo.limitedStrength = true;
+                            // If there is a saved elo value show it in the outputview
+                            // (in that case elo has been set before limitedStrength).
+                            if (savedElo > -1) {
+                                engineInfo.strength = savedElo;
+                            }
+			} else {
+			    engineInfo.limitedStrength = false;
+			}
+                        // Clear savedElo (for next start of the engine)
+                        savedElo = -1; // also done at quit, so maybe it's redundant.
+		    }
+		    if (cmd.startsWith("setoption name MultiPV value")) {
+			engineInfo.nrPvLines = Integer.parseInt(cmd.substring(29));
+		    }
+                    take_write_and_flush(cmd);
+		    continue;                        
+                }
+
+		// Always be ready to send stop
+                if (cmd.equals("stop")) {
+                    take_write_and_flush(cmd);
+                    continue;
+	        }
+		    
+                if (cmd.equals("isready")) {
+		    // We wish to be able to send isready more than
+		    // once during the lifetime of an engineprocess,
+		    // so the next line is important.
+                    readyok = false;
+		    take_write_and_flush(cmd);
+                    continue;
+                }
+                
+                if (!readyok) {
+                    // Wait for readyok before proceeding to
+                    // the sending of other commands below.
+                    continue;
+                }
+
+                // if the command is "position fen moves", first count the
+                // number of moves so far to generate move numbers in engine info
+                // todo: needed???
+                if (cmd.startsWith("position")) {
+                    Matcher matchMoves = REG_MOVES.matcher(cmd);
+                    int cnt = 0;
+                    while (matchMoves.find()) {
+                        cnt++;
+                    }
+                    if (cnt > 0) {
+                        engineInfo.halfmoves = cnt;
                     }
                 }
+                if (cmd.startsWith("position fen")) {
+                    String fen = cmd.substring(13);
+                    engineInfo.setFen(fen);
+                }
+                // All other commands can be sent as they are,
+                // without any action.
+
+                take_write_and_flush(cmd);
+
             }
         }
     }


### PR DESCRIPTION
OK Dominik, heres the modified pull request for engine changes. The latest one didn't quite meet the demands. I had missed some things there. Now I think it seems to hold together quite nicely. The detailed walk through text below is an update with new changes of the text from the last pull request. So, you can just reject the old pull request.
Should this be merged into master, then you can close issue #146.

Whenever you get the time and feel for it, just start with compiling the branch, try it out and see what you think about it. try some different engines, jump between the modes, add and remove pv-lines. Look for flaws and things you don't like and give me feedback.

##### Short summary of visible changes:

The pv-lines will always be shown as many as the MultiPV-option tells. (except after a checkmate when there will be only one, (#0), It's best to keep it that way.) The number of lines is "per-engine" and may change as soon as we choose a new engine, together with the other engineinfo. For added engines it can also be changed in the dialogEngines. pv-lines can always be added or removed (+ or -), even if the active engine is not running. There's a checkbox for turning on/off the pv-lines when playing. The number of pv-lines will be saved and restored (also for internal engine). When pressing Play as black or white in the menu the internal engine will play with elo as before, added engines which support LimitedStrength will then only play with elo if LimitedStrength has been set in the options, and the elo will in that case show directly in the engineID when that engine has been chosen, to notify the user. Some other small fixes have been included.

I've had an engine_improvements-branch in my forked repo of jfxchess (jerry) for a long time and mostly used that branch when running jfxchess. Recently I found some new problems which made me make some new changes on the branch, and it gave me a reason to send all the changes as a pull-request. You can take it as is, change it any way you like or take parts of it to fix some problems, no hurry.

There are quite a lot of changes, and to make your review easier I'll walk you through the changes file by file:

#### DialogNewGame

When starting a game against an engine which doesn't support UCI_LimitStrength, previously "elo 1200" was shining in bright white in the label next to the slidingbar. (I'm running in dark mode) I changed it to "N.A." (for not applicable) and disabled the label. Looks OK.

#### Engine

I chose to make the MultiPV-option visible in DialogEngineOptions, from where it now can also be set as well as with the + and - buttons.

I added the addEngineOption() method in which I manipulate the MultiPV max-value to always be less or equal to GameModel.MAX_PV, 64, just as you do in internal stockfish, but to 4. Otherwise someone could try to enter a bigger value in dialogEngineOptions, which would make the + and - stop working. Stockfish max is 256. Hm, can there really be 256 different moves in a position?

also changed to a call of this new method in two places here.

Added getMultiPV() and setMultiPV().

And I commented-out setUciLimitStrength(), because I don't need it, but needed LimitStrength elsewhere so I added a get-method instead.

#### EngineInfo

First changed, but then simply removed, unused pattern READYOK which was set to "readok" without y. This change was just an editing change that happened to be included. Maybe there are more unused patterns?.

enginInfo.clear() is called from the EngineThread. I found it best to also reset the limitedStrength boolean to false here.

But not resetting nrPvLines to 1. (I chose to always show the number of pvlines stored in the multipv-engineoption of the active engine, even for an unstarted engine.)

#### DialogEngineOptions

Here I have just changed so the multiPV-option will also be displayed as the rest of the parameters. Why not show all the options, when it works well to set the number of PV-lines from here as well as changing it by the + and - buttons?

(Noticed that there is a Stockfish option which has the unusual type "button", "option name Clear Hash type button", which jfxchess doesn't "catch".)

#### DialogEngines

I added the fix for issue #146, the one with the second engine not being removable.

Added a title to the dialog.

Removed some warnings I got with another version of java/javafx.

Included wait for uciok.

skipped "id author"-line.

I call the new method engine.addEngineOptions(), to manipulate MultiPV spinMax value.

Sent stop and quit to the engine before destroying engineProcess.

#### EngineThread

I tried to make the EngineThread more robust and also more "UCI-Protocol friendly", mostly waiting for uciok and readyok not only once (isready should be sent after newgame e.g.). I found it easier to think in a while-continue structure, so some else-cases disappeared. Changing the structure caused many diffs. With this file it's probably best to read it through, and not just look at diffs. It's well commented.

My code was old and in this class I had also missed your migration from skill-level to UCI_LimitStrength and UCI_Elo. I even had to make it more complicated than before. I save the elo-value until we know that UCI_LimitStrength will be sent, instead of setting it directly in the engineInfo. Otherwise we would show the elo in the outputview even if the engine was playing without LimitStrength. (I haven't checked, but maybe the limit-strength-command comes before the elo-command if both options have been set in dialogEngines and in that case the elo-value is set in engineInfo in connection with the elo-command.)

I got rid of some try-catches and copy-paste code by the new method take_write_and_flush(cmd).

I added some methods to be able to just set engineinfo without sending the commands.

#### GameModel

I changed the "storage" of multiPv, so the setMultiPv() and getMultiPV() operates directly on the multiPV-option in the activeEngine. In this way it will always be in sync and can also be set via the options in DialogEngines (for other than internal).

I introduced a new boolean, eloHasBeenSetInGui, and a get and a set-method for it.
 I was testing the elo-functionality for engines that support UCI_LimitStrength and UCI_Elo, other than the internal engine. As you know we play with elo for both "new game" and "play as white or black", I changed it to only play with elo for "new game" where we have given the user a possibility to set the elo in DialogNewGame. It's possible to play with elo also in "play as white or black" but then you have to set lUC_LimitStrength in the DialogEngineOptions. And without limit-strength set it will play without elo of course. I wanted to see that the elo-string came out (or didn't come out) right in the outputview in all cases. Note that the internal engine, where the user can't set the options, will work as it did before, with elo set in all the cases. An idea I have is to create a dialog for "play as white or black" too, with some of the settings from DialogNewGame and make the elo-setting optional there (maybe optional in "new game" too). This eloHasBeenSetInGui boolean would also be good to have then.

(It really doesn't matter much at all, but I noticed that stockfish doesn't play at it's best with limitedStrength even at very high elo. Sometimes it even refrains from mate in one and plays another good move instead. I was completely crushed, as usual ;-) , in a game, but got a draw by threefold repetition because stockfish didn't mate me. And stockfish probably has no track of the game-history because jfxchess just sends a new position each time "position fen ...". Sending the full game with "position startpos moves ...." is something I could try to implement sometime, maybe.)

I also save and restore the internal Stockfish engine. This was to make the showing of multipvlines hang together and be "uniform".

I changed a default value. The default value was actually a bug fix! I noticed recently that Stockfish internal played like a..., well a 1320-player. Other engines played OK as usual. It took me a while before I understood why:
Stockfish internal is the engine which gets some of its options set in the program, other engines are asked for their options and default values in DialogEngines.java. It turned out that Stockfish 17 has a default value of 1320 for UCI_Elo, but it was set to 3190 in the program. The thing is that before sending an option value there is a check in the code that it's not the same as the default value. Trying to set the value to 3190, with a default value of 3190 meant that the value never was sent to the engine. As UCI_LimitStrength was set to true, stockfish still used its own default value 1320 for the elo.

(It got even more weird when I thought I had fixed the problem by setting the correct value and stockfish still played like 1320. But I was playing stockfish 14 then (as internal , maybe by a fix) and that version has a max Elo of 2800-something. When trying to set 3190 apparently stockfish 14 just refused , and kept using it's low Elo default value.)
Maybe an idea would be to also ask stockfish internal for it's values as well as other engines, and then you wouldn't have to change values for a new stockfish release ever again.

However, after just changing the default value to 1320 in the code, with stockfish 17 as internal engine it now works well again and, as I wrote, for other engines than the internal this was never a problem. And even if they happen to have 3190 as default they would just fallback to exactly 3190 anyway ;-)

#### EngineOutputView

Added the boolean, pvLinesAreEnabled, and the functionality to turn of showing pvlines when playing a game, enablePVLines() and disablePVLines().

I took the liberty to remove some out-commented code with the "pv1, pv2, pv3, pv4" still hanging around.

Assembled a resetPVLines() method from pieces of code in stateChange() and called it twice.

Changed the stateChanged() method slightly and added a little fix at the bottom. When you are in analysis mode, wait until the "depth-text" appears and then directly start a new game, the last depth-text from the analysys remains there (throughout the game with stockfish it seems, or until a new depth is presented during the game with some engines). It seems to be fixed by clearing the depth-text for each state-change.

And a similar fix for nps.

#### EngineController

The general idea was to move knowledge of Engine-specific things into the EngineController., such as UCI-commands and checks like isInternal and supportsLimitStrength before sending the commands.

Most of these changes were made a long time ago. I don't remember exactly, but I had some problems with some engines (not stockfish I think) not quitting correctly and after changing modes back and forth there could even be two EngineProcesses at the same time when I checked with the ps command. Don't know if this solved any problem or if it was solved somewhere inside the enginThread, but It seems that I wanted to be absolutely sure that there was only one engineThread instance, so I create that instance once in the EngineController constructor, and it will last for as long as the program is running. It will not load the processor too hard when the engineProcess is not running, because of a sleep inside the loop in the Enginethread.

I put the content of startEngineThread() inside the constructor().

Then I added the inGoInfinite boolean and, in sendCommand(), the functionality of sending stop before a new command if we are in "go infinite"-mode here instead of in the EngineThread as it was before. I had missed that, which was part of my problem with adding pv-lines.

Added new stopEngine() and restartEngine() functions to be called from ModeMenuController to always start and stop the engine in the same way. Added an isready after newgame (and then I had to make the engineThread able to wait for readyok more than once).

I commented-out some methods connected to skill level and the testStartAndGoInf(), for which I could not find any callers anymore.

I had a deep think ;-) over the problem with the ELO setting and UCI_LimitStrength. One of the problems was that if the elo is set to default when limit-strength is set, then the elo command was never sent to the engine - So what? It will play with the default elo anyway. Yes, but the elo setting will not be visible in the outputview, because that happened in the Enginethread when the elo-command was sent, which it wasn't. So, I made an exception for the setoption-elo-command, to always send the elo-command when an engine starts, even if it has the default value.

At the end there's engineInfoSetValues(), see comment.

(All the commands go through sendCommand() just because I wanted one place where I could put a System.out.println() to see them, and I didn't have to write try-catch each time ;-) ) (Not exactly true really, because the EngineThread sometimes, and the dialogEngines send commands directly into their cmdQueue.)

#### ModeMenuController

I moved the EngineController instance from App.java to here. There's no reason for this really. (Well, I had a reason: I was experimenting with a "mini-jerry"-program and didn't want to bring in the whole App.java)

Most of the changes consist only of calling the methods in engineContoller instead of specifing the commands Explicitly here.

Well, there's one difference. I set uciLimitStrength directly to the engine when it has been started. You manipulate the option parameter first so It will be sent when the engine starts. It's a little unclear which is best but I went for the less tricky idea, to send it directly to the engine.

I have added a check of the new boolen in activatePlayWhiteMode and ...BlackMode before sending setUciLimitStrength(true) to the EngineController:
if (gameModel.activeEngine.isInternal() || gameModel.eloHasBeenSetInGUI()) 
and a reset to false when it has been handled.

I added setEngineInfoForUnstartedEngine(), see the comment in the code for info, and a call to that method in editEngines(). It's also called from restoreEngines in App.java.

If we are playing an engine and then choose Engines... in the Mode-menu, then the engineOutputwindow will show "Off", but the engineProcess is still running. The same thing happend after checkmate for instance). Maybe that was deliberate, but now I call activateEnterMovesMode which also stops the engine in both cases.

Reagarding issue #148 about the result-notifications, I managed to get rid of the first notification when choosing Engines in the menu, by wrapping editEngines in a doNotNotifyAboutResult = true and a false-setting at the end.

The problem i mentioned before (see below) has been solved now, or should i say avoided?, because for other engines than the internal we don't play with elo unless it's a new game, when the elo has been chosen in the gui (or if LimitStrength has been set explicitly in dialogEngineOptions):

old problem: Just a while ago I realized that it's dangerous to set UCI_limitStrength to true as in activatePlayWhiteMode() and activatePlayBlackMode(). It's probably OK for the internal engine, but what if it's an engine we have added that supports UCI_LimitStrength, Arasan or just a newer version of Stockfish maybe? It's very probable that we have never set an ELO-value for the engine. If then the first thing we do with this engine is e.g. "play as white", We will set UCI_LimitStrength to true, and the engine will use it's low default-ELO when playing. Yep, that's what happened when I tried. That problem disappeared, of course, when I added
if (gameModel.activeEngine.isInternal()). Don't know if it's a full solution though.

#### App

Well, there was this moving of engineController which is visible in some of the changes.

Added the functionality to hide the pv-lines while playing.

Added the label Engines: just for clarity.

The "restored active engine is now showing in outputview at start".

Added checks so we stay within the limits for the number of PV-lines when pressing + or -. (The same as in game-model)

Fixed so the "Enter Moves"-menuitem will be selected after e.g. editing engines.

Some UCI command not directly visible anymore.

Here I set the new boolean in gameModel, eloHasBeenSetInGUI, when a new game isstarted with elo-setting.