### PR TITLE
Return of equality

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/MoveView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/MoveView.java
@@ -119,13 +119,13 @@ public class MoveView implements StateChangeListener {
 
         Menu posAnnotation = new Menu("Position Annotation");
         MenuItem unclear = new MenuItem("∞ Unclear");
-        MenuItem drawish = new MenuItem("= Drawish");
+        MenuItem drawish = new MenuItem("= Equal");
         MenuItem slightAdvantageWhite = new MenuItem("⩲ Slight Advantage White");
         MenuItem slightAdvantageBlack = new MenuItem("⩱ Slight Advantage Black");
         MenuItem advantageWhite = new MenuItem("+- Advantage White");
         MenuItem advantageBlack = new MenuItem("-+ Advantage Black");
         MenuItem noPosAnnotation = new MenuItem("No Position Annotation");
-        posAnnotation.getItems().addAll(unclear, slightAdvantageWhite, slightAdvantageBlack, advantageWhite, advantageBlack, noPosAnnotation);
+        posAnnotation.getItems().addAll(unclear, drawish, slightAdvantageWhite, slightAdvantageBlack, advantageWhite, advantageBlack, noPosAnnotation);
 
         MenuItem removeAnnotation = new MenuItem("Remove Annotations");
         SeparatorMenuItem separator1 = new SeparatorMenuItem();
@@ -375,7 +375,7 @@ public class MoveView implements StateChangeListener {
         try {
             if(rightClickedNode >= 0) {
                 GameNode selectedNode = gameModel.getGame().findNodeById(rightClickedNode);
-                selectedNode.removeNagsInRange(0,8);
+                selectedNode.removeNagsInRange(0,CONSTANTS.MOVE_ANNOTATION_UPPER_LIMIT);
                 gameModel.getGame().setTreeWasChanged(true);
                 gameModel.triggerStateChange();
             }
@@ -459,7 +459,8 @@ public class MoveView implements StateChangeListener {
         try {
             if(rightClickedNode >= 0) {
                 GameNode selectedNode = gameModel.getGame().findNodeById(rightClickedNode);
-                selectedNode.removeNagsInRange(9,20);
+                selectedNode.removeNagsInRange(CONSTANTS.POSITION_ANNOTATION_LOWER_LIMIT,
+                                                CONSTANTS.POSITION_ANNOTATION_UPPER_LIMIT);
                 gameModel.getGame().setTreeWasChanged(true);
                 gameModel.triggerStateChange();
             }
@@ -471,7 +472,7 @@ public class MoveView implements StateChangeListener {
         try {
             if(rightClickedNode >= 0) {
                 GameNode selectedNode = gameModel.getGame().findNodeById(rightClickedNode);
-                selectedNode.removeNagsInRange(0,139);
+                selectedNode.removeNagsInRange(0,CONSTANTS.POSITION_ANNOTATION_UPPER_LIMIT);
                 gameModel.getGame().setTreeWasChanged(true);
                 gameModel.triggerStateChange();
             }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/CONSTANTS.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/CONSTANTS.java
@@ -489,8 +489,12 @@ public class CONSTANTS {
     public static final int RES_BLACK_WINS = 2;
     public static final int RES_DRAW = 3;
     public static final int RES_ANY = 4;
+    
+    public static final int MOVE_ANNOTATION_UPPER_LIMIT = 9;
+    public static final int POSITION_ANNOTATION_LOWER_LIMIT = 10;
+    public static final int POSITION_ANNOTATION_UPPER_LIMIT = 135;
 
-    public static int NAG_NULL = 0;
+    //public static int NAG_NULL = 0;
     public static final int NAG_GOOD_MOVE = 1;
     //A good move. Can also be indicated by ``!`` in PGN notation."""
     public static final int NAG_MISTAKE = 2;

--- a/src/main/java/org/asdfjkl/jfxchess/lib/Game.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/Game.java
@@ -308,7 +308,7 @@ public class Game {
     }
 
     public void removeAllAnnotationsRec(GameNode node) {
-        node.removeNagsInRange(0,120);
+        node.removeNagsInRange(0, CONSTANTS.POSITION_ANNOTATION_UPPER_LIMIT);
         for(GameNode var_i : node.getVariations()) {
             this.removeAllAnnotationsRec(var_i);
         }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/GameNode.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/GameNode.java
@@ -176,17 +176,21 @@ public class GameNode {
     }
 
     public void addNag(int n) {
+        int maUpperLimit = CONSTANTS.MOVE_ANNOTATION_UPPER_LIMIT;
+        int paLowerLimit = CONSTANTS.POSITION_ANNOTATION_LOWER_LIMIT;
+        int paUpperLimit = CONSTANTS.POSITION_ANNOTATION_UPPER_LIMIT;    
         if(!nags.contains(n)) {
             // if move annotation, first remove
             // old move annotation
-            if(n > 0 && n < 11) {
-                removeNagsInRange(1,10);
+            if(n > 0 && n <= maUpperLimit) {
+                removeNagsInRange(1,maUpperLimit);
             }
             // same for position annotation
-            if(n > 12 && n < 20) {
-                removeNagsInRange(12,20);
+            if(n >= paLowerLimit && n <= paUpperLimit) {
+                removeNagsInRange(paLowerLimit,paUpperLimit);
             }
             this.nags.add(n);
+            sortNags();
         }
     }
 
@@ -212,7 +216,7 @@ public class GameNode {
         this.nags = filteredNags;
     }
 
-    public void sortNags() {
+    private void sortNags() {
         Collections.sort(this.nags);
     }
 


### PR DESCRIPTION
A much smaller pull request this time!

I've been home from work for three days now, caught a cold. So I took some time to mess with your program, as you may have noticed ;-). It's a nice hobby, and a nice program.

Sometimes I go through my chess games with jfxchess and stockfish when they're finished, noting down mistakes and missed opportunites and good moves for that matter, adding some variations. And I felt I was missing the equality, =, position annotation. So I have "restored" it into jfxchess on this branch. It seems it has been there sometime before, because there was a readymade menu item and an action-method for it.  I called it "Equal" in the menu item. "Drawish" is such a drawish name ;-), no but it could be a wild position evaluated as equal by stockfish and you just want to note
that evaluation. One player has fought hard and finally reached equality evalution by Stockfish. I dont know, you decide the name, "Equal", "Equality", "Equal position", "Drawish" or whatever.
And one can always write a comment instead, or maybe use the "unclear"-annotation.

First I tried to just add the menu-item to the menu, but I noticed that I could add two position evaluations to the same move, = and another one. I think it was the limits in addNag() in GameNode that didn't consider NAG number 10 to be a position annotation. And in other places the limits seemed a little randomly chosen. So I made constants for the limits and used them in all the places instead. Couldn't find any use of NAG_NULL, so I marked that by commenting it out.

I noticed then that I could put the move annotation after the position annotation, Nf3+-!. I found the unused sort method, which I made private and called at the end of addNag -> Nf3!+-, feels better.