### PR TITLE
Loading Gaviota and option type button impl.

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngineOptions.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngineOptions.java
@@ -95,7 +95,7 @@ public class DialogEngineOptions {
             Label lblEnOpt = new Label(enOpt.name+":");
             gridPane.add(lblEnOpt, 0, i);
 
-            if(enOpt.type == EN_OPT_TYPE_CHECK) {
+            if(enOpt.type == EN_OPT_TYPE_CHECK || enOpt.type == EN_OPT_TYPE_BUTTON) {
                 CheckBox cbEnOpt = new CheckBox();
                 cbEnOpt.setSelected(enOpt.checkStatusValue);
                 checkboxWidgets.put(enOpt.name, cbEnOpt);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -232,7 +232,7 @@ public class DialogEngines {
             for(EngineOption enOpt : selectedEngine.options) {
 
                 String optName = enOpt.name;
-                if(enOpt.type == EN_OPT_TYPE_CHECK) {
+                if(enOpt.type == EN_OPT_TYPE_CHECK || enOpt.type == EN_OPT_TYPE_BUTTON) {
                     CheckBox widget = dlg.checkboxWidgets.get(optName);
                     if(widget != null) {
                         enOpt.checkStatusValue = widget.isSelected();

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
@@ -46,7 +46,8 @@ public class Engine {
         for(EngineOption enOpt : options) {
             sb.append('|');
             sb.append(enOpt.toUciOptionString());
-            if(enOpt.type == EngineOption.EN_OPT_TYPE_CHECK) {
+            if(enOpt.type == EngineOption.EN_OPT_TYPE_CHECK || 
+               enOpt.type == EngineOption.EN_OPT_TYPE_BUTTON) {
                 if(enOpt.checkStatusValue) {
                     sb.append("|true");
                 } else {
@@ -84,7 +85,8 @@ public class Engine {
                 EngineOption option = new EngineOption();
                 String uciOptionString = values[i];
                 option.parseUciOptionString(uciOptionString);
-                if(option.type == EngineOption.EN_OPT_TYPE_CHECK) {
+                if(option.type == EngineOption.EN_OPT_TYPE_CHECK ||
+                   option.type == EngineOption.EN_OPT_TYPE_BUTTON) {
                     if(values[i+1].equals("true")) {
                         option.checkStatusValue = true;
                     } else {


### PR DESCRIPTION
Here's a small pull request.
In another pull request which I will send you soon, I added a user dialog if we catch an exception during the loading of an engine. For one engine, called Gaviota, which I downloaded long ago, I got the
following message:

![Add_engine_message1](https://github.com/user-attachments/assets/a245b2ed-59cf-4f3e-9205-1d695dd2f6e3)

Along with it came a NumberFormatException.
It came from the parsing of the optionString. The name of the option contains the word "default", before "type", which jfxchess couldn't handle. (I'm not sure if it's allowed to have it that way. This and some other option names contained "min" or "max", but surrounded by paranthesis, default seems to have been forgotten in that matter).
Anyway, the continued parsing of default value looked at the first "default" and tried to parse "type" as a number.

To prevent words in the name from messing up the parsing I decided to cut the optionString (option line) just before the word "type" and use only the second half for further parsing, and after that Gaviota loaded smoothly.

In this pull request I also consider the rare "type button". It seems that the only difference to a "type check"-option is that we don't have to supply a value (true or false) when we send the command to the engine, so I implemented it very similarly to a "type check"-option.

Gaviota had such an option and Stockfish's "Clear Hash" is now visible in dialogEngineOptions. And I checked that the command "setoption name Clear Hash" comes out right (or don't come out when it shouldn't). And the value was restored right.
