### PR TITLE
Sorted engines

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -95,15 +95,15 @@ public class DialogEngines {
                     btnEditParameters.setDisable(true);
                     btnResetParameters.setDisable(true);
                     btnRemove.setDisable(true);
-                } else if(selectedIndex == 1) {
-                    btnEditParameters.setDisable(false);
-                    btnResetParameters.setDisable(false);
-                    btnRemove.setDisable(true);
-                } else
-                {
+                } else {
                     btnEditParameters.setDisable(false);
                     btnResetParameters.setDisable(false);
                     btnRemove.setDisable(false);
+                }
+                if (engineList.size() >= GameModel.MAX_N_ENGINES) {
+                    btnAdd.setDisable(true);
+                } else {
+                    btnAdd.setDisable(false);
                 }
             }
         });
@@ -208,11 +208,6 @@ public class DialogEngines {
         engineList.remove(selectedEngine);
         // Don't know how the size could have got bigger
         // when we removed an engine, but...
-        if(engineList.size() > GameModel.MAX_N_ENGINES - 1) {
-            btnAdd.setDisable(true);
-        } else {
-            btnAdd.setDisable(false);
-        }
     }
 
     private void btnResetParametersClicked() {
@@ -332,6 +327,7 @@ public class DialogEngines {
 
                 if(engine.getName() != null && !engine.getName().isEmpty()) {
                     engineList.add(engine);
+                    engineList.sort(engine);
                     int idx = engineList.indexOf(engine);
                     Platform.runLater(new Runnable() {
                         @Override
@@ -346,12 +342,6 @@ public class DialogEngines {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-        }
-
-        if(engineList.size() > GameModel.MAX_N_ENGINES - 1) {
-            btnAdd.setDisable(true);
-        } else {
-            btnAdd.setDisable(false);
         }
     }
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Engine.java
@@ -19,8 +19,10 @@
 package org.asdfjkl.jfxchess.gui;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import org.asdfjkl.jfxchess.lib.CONSTANTS;
 
-public class Engine {
+public class Engine implements Comparator<Engine>{
 
     private String name = "";
     private String path = "";
@@ -202,4 +204,15 @@ public class Engine {
             }
         }
     }
-}
+
+    @Override
+    public int compare(Engine o1, Engine o2) {
+        if (o1.name.equals(CONSTANTS.INTERNAL_ENGINE_NAME)) {
+            return -1;
+        }
+        if (o2.name.equals(CONSTANTS.INTERNAL_ENGINE_NAME)) {
+            return 1;
+        }
+        return o1.name.compareTo(o2.name);
+    }
+ }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
@@ -24,7 +24,7 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 import org.asdfjkl.jfxchess.lib.Board;
 import org.asdfjkl.jfxchess.lib.PolyglotExtEntry;
-
+import org.asdfjkl.jfxchess.lib.CONSTANTS;
 import java.util.ArrayList;
 
 public class EngineOutputView implements StateChangeListener {
@@ -51,7 +51,7 @@ public class EngineOutputView implements StateChangeListener {
 
         this.gameModel = gameModel;
 
-        this.engineId = new Text("Stockfish (internal)");
+        this.engineId = new Text(CONSTANTS.INTERNAL_ENGINE_NAME);
         this.depth = new Text("");
         this.nps = new Text("");
         Text pvLine = new Text("");

--- a/src/main/java/org/asdfjkl/jfxchess/gui/GameModel.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/GameModel.java
@@ -109,7 +109,7 @@ public class GameModel {
         // String bookPath = getBookPath();
 
         Engine stockfish = new Engine();
-        stockfish.setName("Stockfish (Internal)");
+        stockfish.setName(CONSTANTS.INTERNAL_ENGINE_NAME);
         if(stockfishPath != null) {
             stockfish.setPath(stockfishPath);
         }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/CONSTANTS.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/CONSTANTS.java
@@ -21,6 +21,9 @@ package org.asdfjkl.jfxchess.lib;
 public class CONSTANTS {
 
     private CONSTANTS() {}
+    
+    public static final String INTERNAL_ENGINE_NAME =
+	new String("Stockfish (Internal)");
 
     public static final int EMPTY = 0;
     public static final int PAWN = 1;


### PR DESCRIPTION
Hello Dominik!
I figured I should be of some use and cross something off your list of things to do.
In some issue there was a suggestion to sort the Engine-list.
Well, we can see all the max 10 engines without scrolling, so it's not a big improvement,
but here it is.

Stockfish (Internal) keeps its privilege of being number zero, it would become too messy otherwise.
The others are sorted alphabetically.

Also noted that if we had 10 engines in the list and opened the EngineDialog, the Add button
was not disabled. (It worked when an engine was added or deleted). I moved the setting
of disabled to true or false into the changed() method, where it probably belongs, and removed the
 other two. Perhaps it was me who put them there once ago.

Also misspelled Stockfish (Internal) with a lowercase i instead and therefore made a constant of it.
In some of the files the only change is the use of this constant.
