### PR TITLE
hashfull and tbhits

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
@@ -34,6 +34,9 @@ public class EngineOutputView implements StateChangeListener {
     private final Text engineId;
     private final Text depth;
     private final Text nps;
+    private final Text hashFull;
+    private final Text tbHits;
+    
     /*
     private final Text pv1;
     private final Text pv2;
@@ -44,8 +47,18 @@ public class EngineOutputView implements StateChangeListener {
     private final ArrayList<Text> pvLines;
 
     private boolean isEnabled = true;
+    
+    private boolean pvLinesAreEnabled = true;
 
     private TextFlow txtEngineOut;
+
+    // This is the index of the first pv-line
+    // among the children in txtEngineOut.
+    private final int FirstPVLineChildIndex = 11; 
+
+    // This is the index of the first pv-line
+    // in the split String infos.
+    private final int FirstPVLineInfosIndex = 7; 
 
     public EngineOutputView(GameModel gameModel, TextFlow txtEngineOut) {
 
@@ -54,18 +67,16 @@ public class EngineOutputView implements StateChangeListener {
         this.engineId = new Text("Stockfish (internal)");
         this.depth = new Text("");
         this.nps = new Text("");
+        this.hashFull = new Text("");
+        this.tbHits = new Text("");
         Text pvLine = new Text("");
         this.pvLines = new ArrayList<Text>();
         this.pvLines.add(pvLine);
-        /*
-        this.pv1 = new Text("");
-        this.pv2 = new Text("");
-        this.pv3 = new Text("");
-        this.pv4 = new Text("");
-        */
 
         Text spacer1 = new Text("     ");
         Text spacer2 = new Text("     ");
+        Text spacer3 = new Text("     ");
+        Text spacer4 = new Text("     ");
 
         this.txtEngineOut = txtEngineOut;
 
@@ -75,21 +86,14 @@ public class EngineOutputView implements StateChangeListener {
                 this.depth,
                 spacer2,
                 this.nps,
+                spacer3,
+                this.hashFull,
+                spacer4,
+                this.tbHits,
                 new Text(System.lineSeparator()),
                 new Text(System.lineSeparator()),
                 pvLines.get(0),
                 new Text(System.lineSeparator()));
-
-        /*
-                this.pv1,
-                new Text(System.lineSeparator()),
-                this.pv2,
-                new Text(System.lineSeparator()),
-                this.pv3,
-                new Text(System.lineSeparator()),
-                this.pv4);
-        */
-        //this.txtEngineOut.getChildren().addAll(currentEval);
     }
 
     public void enableOutput() { isEnabled = true; }
@@ -106,15 +110,11 @@ public class EngineOutputView implements StateChangeListener {
         engineId.setText("");
         depth.setText("");
         nps.setText("");
+        hashFull.setText("");
+        tbHits.setText("");
         for(Text pvLine : pvLines) {
             pvLine.setText("");
         }
-        /*
-        pv1.setText("");
-        pv2.setText("");
-        pv3.setText("");
-        pv4.setText("");
-        */
     }
 
     public void setText(String info) {
@@ -122,7 +122,11 @@ public class EngineOutputView implements StateChangeListener {
         if(isEnabled) {
 
             //pv1.setText(info);
-            // | id (Level MAX) | zobrist  |  nps | current Move + depth | eval+line pv1 | .. pv2 | ...pv3 | ...pv4
+            // | id (Level MAX) | zobrist  |  nps | hashfull | tbhits | current Move + depth | eval+line pv1 | .. pv2 | ...pv3 | ...pv4 | ... | ...pv64 |
+
+            // Note: All trailing empty matched strings will not 
+            // be part of infos, so we have to check infos.length().
+            // But there can be empty strings "in between".
             String[] infos = info.split("\\|");
 
             if (infos.length > 1 && !infos[1].isEmpty()) {
@@ -132,42 +136,76 @@ public class EngineOutputView implements StateChangeListener {
                 nps.setText(infos[3]);
             }
             if (infos.length > 4 && !infos[4].isEmpty()) {
-                depth.setText(infos[4]);
+                hashFull.setText(infos[4]);
+            }
+            if (infos.length > 5 && !infos[5].isEmpty()) {
+                tbHits.setText(infos[5]);
+            }
+            if(infos.length > 6 && !infos[6].isEmpty()) {
+                depth.setText(infos[6]);
             }
 
-            if(infos.length > 5 && !infos[5].isEmpty()) {
-                pvLines.get(0).setText(infos[5]);
+            if(!pvLinesAreEnabled) {
+                return;
             }
 
-            for(int i=6;i<infos.length;i++) {
-                if(pvLines.size() > i-5) {
+            // Set but don't clear the first pvLine-text.
+            if(infos.length > FirstPVLineInfosIndex && !infos[ FirstPVLineInfosIndex].isEmpty()) {
+                pvLines.get(0).setText(infos[7]);
+            }
+
+            // Set the rest of the pvLine-texts or clear them if they are empty.
+            for(int i=FirstPVLineInfosIndex+1;i<infos.length;i++) {
+                if(pvLines.size() > i-FirstPVLineInfosIndex) {
                     if(!infos[i].isEmpty()) {
-                        pvLines.get(i-5).setText(infos[i]);
+                        pvLines.get(i-FirstPVLineInfosIndex).setText(infos[i]);
                     } else {
-                        pvLines.get(i-5).setText("");
+                        pvLines.get(i-FirstPVLineInfosIndex).setText("");
                     }
                 }
             }
         }
     }
 
-
-    @Override
-    public void stateChange() {
-
-        if(gameModel.wasMultiPvChanged()) {
-            // remove all old widgets
-            int cntChildren = txtEngineOut.getChildren().size();
-            txtEngineOut.getChildren().remove(7, cntChildren);
-            pvLines.clear();
+    public void disablePVLines() {
+        if (pvLinesAreEnabled) {
+            resetPVLines();
+            depth.setText("");
+	    nps.setText("");
         }
-        gameModel.setMultiPvChange(false);
-        for(int i=0;i<gameModel.getMultiPv();i++) {
+        pvLinesAreEnabled = false;
+    }
+    
+    public void enablePVLines() {
+        pvLinesAreEnabled = true;
+    }
+
+    private void resetPVLines() {
+        int cntChildren = txtEngineOut.getChildren().size();
+        txtEngineOut.getChildren().remove(FirstPVLineChildIndex, cntChildren);
+        pvLines.clear();
+        for (int i = 0; i < gameModel.getMultiPv(); i++) {
             Text pvLine = new Text("");
             pvLines.add(pvLine);
             txtEngineOut.getChildren().add(pvLine);
             txtEngineOut.getChildren().add(new Text(System.lineSeparator()));
         }
+    }
+
+    @Override
+    public void stateChange() {
+        if(gameModel.wasMultiPvChanged()) {
+            resetPVLines();
+            gameModel.setMultiPvChange(false);
+        }
+        // The last depth-text from analysis mode remained after mode change 
+        // to playing black or white (or to a new game).
+        depth.setText("");
+        // There was a similar problem with nps (but this didn't seem to
+        // help completely).
+	nps.setText("");
+	hashFull.setText("");
+	tbHits.setText("");
     }
 
 }


### PR DESCRIPTION
I made an attempt to cross the "showing hashfull and tbhits"-workcase off your roadmap. This pull request is just basically showing them, but what is your idea about the design? Do you want to show tbhits 0 for almost the entire game or only show tbhits if the engine reports some tbhits in the endgame? I'm not sure exactly how it works. You wrote "hash percentage", but it comes out as 0-1000 (per mille). Shall I convert to % and add the %-unit? Anything else?

Apart from adding hashfull and tbhits:

#### EngineInfo

I included a few independent diffs from the Engine_2 branch here.
Introduced the getInt() method which perhaps saved some writing.

#### EngineOutputView

Replaced some numbers with constants, telling what the numbers stand for.

There is a small bug on the master branch in the stateChange() method. It doesn't seem to cause any problems. If we enter stateChange() with wasMultiPvChanged() returning true, then there's no problem at all. But if we trigger stateChange() by e.g. just clicking a move in the game, then we'll just add more lines to pvLines and more children to txtEngineOut without first having "cleared" those variables. I guess the for-loop was ment to be inside the if(gameModel.wasMultiPvChanged())-block.

In the Engines_2 branch I assembled that code into resetPVLines() and always called that method in stateChange(). But that has the negative visible effect that the area of the pv-lines "flashes" empty for a short moment sometimes at state-change. So, forget that, I changed my mind, call the resetPVLines() inside the if-block as here. (And then we can't remove the wasPvChanged-functionality as I wrote before in a comment that we probably can.)

There's no caller of disablePVLines() yet of course, but I have prepared the class for optionally not showing any pv-lines when playing, so the file looks much like the one on Engines_2.