### PR TITLE
DialogEngines + exception fix

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
@@ -163,7 +163,11 @@ public class EngineInfo {
 
             String line = lines[i];
             
-            multiPv = getInt(MULTIPV, line, 8, multiPv) - 1;
+            Matcher matchPVIdx = MULTIPV.matcher(line);
+            if(matchPVIdx.find()) {
+                String sMultiPV = matchPVIdx.group();
+                multiPv = Integer.parseInt(sMultiPV.substring(8)) - 1;
+            }
             
             nps = getInt(NPS, line, 4, nps);
             hashFull = getInt(HASHFULL, line, 9, hashFull);


### PR DESCRIPTION
Hello Dominik!
Thanks for merging my pull requests, felt good ;-)
I had also merged them all into my workbranch when I saw that you beat me to it.
I also messed up DialogEngines a bit first because of the conflicts.
Now I send a version of that file which I'm content with.  Your changes are there too.
I added a few blank characters I had missed in the exception texts.
Moved "EngineOtion option = new ... " closer to where it's being used.

And I had messed up EngineInfo and got an exception. I used my new getInt() for MultiPV
where it couldn't be used, because of the trailing -1. It's only if there has been a match
that 1 should be subtracted of course.

In principle you can just copy the two files, as they are, into master. Practically all diffs 
between yours and my merge were in DialogEngines, which is a good sign.

I should have figured out that there was more to sorting the engine-list than just putting
the engines in alphabetic order. You would have done it long ago if it was so simple.

I tried it out and checked at least most the  new features.
